### PR TITLE
Fixed bug with accessing cutting tool object props

### DIFF
--- a/src/app/widgets/Visualizer/Visualizer.jsx
+++ b/src/app/widgets/Visualizer/Visualizer.jsx
@@ -267,11 +267,23 @@ class Visualizer extends Component {
         }
 
         // Whether to show cutting tool or cutting pointer
-        if (this.cuttingTool && this.cuttingPointer && (state.liteMode) ? (this.cuttingTool.visibleLite !== state.objects.cuttingTool.visibleLite) : (this.cuttingTool.visible !== state.objects.cuttingTool.visible)) {
+        if (
+            state.liteMode
+                ? (this.cuttingTool?.visibleLite !== state.objects.cuttingTool.visibleLite)
+                : (this.cuttingTool?.visible !== state.objects.cuttingTool.visible)
+        ) {
             const { liteMode } = state;
-            this.cuttingTool.visible = liteMode ? state.objects.cuttingTool.visibleLite : state.objects.cuttingTool.visible;
-            this.cuttingPointer.visible = liteMode ? !state.objects.cuttingTool.visibleLite : !state.objects.cuttingTool.visible;
-            needUpdateScene = true;
+            if (this.cuttingTool?.visible) {
+                this.cuttingTool.visible = liteMode ? state.objects.cuttingTool.visibleLite : state.objects.cuttingTool.visible;
+            }
+
+            if (this.cuttingPointer?.visible) {
+                this.cuttingPointer.visible = liteMode ? !state.objects.cuttingTool.visibleLite : !state.objects.cuttingTool.visible;
+            }
+
+            if (this.cuttingTool?.visible && this.cuttingPointer?.visible) {
+                needUpdateScene = true;
+            }
         }
 
         { // Update position


### PR DESCRIPTION
Weird that your checkers don't work for whatever reason, but this is my solution. From what I've tested it seems to be working fine now.